### PR TITLE
Empty state / only allowing specific widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,66 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+
+
+### Only select certain widgets to be displayed
+
+Set the allowed_widgets config. Set this value to null if you want to show all widgets of the panel.
+
+```php
+return [
+    'allowed_widgets' => [
+        RunningProjectsChart::class,
+        BrutoMarginChart::class,
+        ApprovedQuotes::class,
+        FollowUpTableWidget::class,
+        PaymentRemindersTableWidget::class
+    ]
+];
+```
+
+### Set an empty state (when the user hasn't chosen any widgets)
+Set the empty_state_widgets` config.
+
+```php
+return [
+    'empty_state_widgets' =>
+    [
+        [
+            "widget" => RunningProjectsChart::class,
+            "x" => 0,
+            "y" => 0,
+            "w" => 6,
+        ],
+        [
+            "widget" => BrutoMarginChart::class,
+            "x" => 6,
+            "y" => 0,
+            "w" => 6,
+        ],
+
+        [
+            "widget" => ApprovedQuotes::class,
+            "x" => 0,
+            "y" => 1,
+            "w" => 12,
+        ],
+        [
+            "widget" => FollowUpTableWidget::class,
+            "x" => 0,
+            "y" => 2,
+            "w" => 12,
+        ],
+        [
+            "widget" => PaymentRemindersTableWidget::class,
+            "x" => 0,
+            "y" => 3,
+            "w" => 12,
+        ]
+    ]
+];
+```
+
 ## Testing
 
 ```bash

--- a/config/gridstack-dashboard.php
+++ b/config/gridstack-dashboard.php
@@ -5,7 +5,7 @@ return [
     'navigation_sort' => null,
     'navigation_group' => null,
 
-    'allowed_widgets' => [],
+    'allowed_widgets' => null,
 
     'empty_state_widgets' => []
 ];

--- a/config/gridstack-dashboard.php
+++ b/config/gridstack-dashboard.php
@@ -1,54 +1,11 @@
 <?php
 
-use App\Filament\App\Widgets\ApprovedQuotes;
-use App\Filament\App\Widgets\BalanceChart;
-use App\Filament\App\Widgets\BrutoMarginChart;
-use App\Filament\App\Widgets\PaymentRemindersTableWidget;
-use App\Filament\App\Widgets\RunningProjectsChart;
-use Bouwflow\Crm\Filament\Crm\Widgets\FollowUpTableWidget;
-
 return [
     'should_register_navigation' => true,
-    'navigation_sort' => -5,
-    'navigation_group' => 'Algemeen',
+    'navigation_sort' => null,
+    'navigation_group' => null,
 
-    'allowed_widgets' => [
-        RunningProjectsChart::class,
-        BrutoMarginChart::class,
-        ApprovedQuotes::class,
-        FollowUpTableWidget::class,
-        PaymentRemindersTableWidget::class,
-    ],
+    'allowed_widgets' => [],
 
-    'empty_state_widgets' => [
-        "widget" => RunningProjectsChart::class,
-        "x" => 0,
-        "y" => 0,
-        "w" => 6,
-    ],
-    [
-        "widget" => BrutoMarginChart::class,
-        "x" => 6,
-        "y" => 0,
-        "w" => 6,
-    ],
-
-    [
-        "widget" => ApprovedQuotes::class,
-        "x" => 0,
-        "y" => 1,
-        "w" => 12,
-    ],
-    [
-        "widget" => FollowUpTableWidget::class,
-        "x" => 0,
-        "y" => 2,
-        "w" => 12,
-    ],
-    [
-        "widget" => PaymentRemindersTableWidget::class,
-        "x" => 0,
-        "y" => 3,
-        "w" => 12,
-    ]
+    'empty_state_widgets' => []
 ];

--- a/config/gridstack-dashboard.php
+++ b/config/gridstack-dashboard.php
@@ -1,4 +1,54 @@
 <?php
 
+use App\Filament\App\Widgets\ApprovedQuotes;
+use App\Filament\App\Widgets\BalanceChart;
+use App\Filament\App\Widgets\BrutoMarginChart;
+use App\Filament\App\Widgets\PaymentRemindersTableWidget;
+use App\Filament\App\Widgets\RunningProjectsChart;
+use Bouwflow\Crm\Filament\Crm\Widgets\FollowUpTableWidget;
+
 return [
+    'should_register_navigation' => true,
+    'navigation_sort' => -5,
+    'navigation_group' => 'Algemeen',
+
+    'allowed_widgets' => [
+        RunningProjectsChart::class,
+        BrutoMarginChart::class,
+        ApprovedQuotes::class,
+        FollowUpTableWidget::class,
+        PaymentRemindersTableWidget::class,
+    ],
+
+    'empty_state_widgets' => [
+        "widget" => RunningProjectsChart::class,
+        "x" => 0,
+        "y" => 0,
+        "w" => 6,
+    ],
+    [
+        "widget" => BrutoMarginChart::class,
+        "x" => 6,
+        "y" => 0,
+        "w" => 6,
+    ],
+
+    [
+        "widget" => ApprovedQuotes::class,
+        "x" => 0,
+        "y" => 1,
+        "w" => 12,
+    ],
+    [
+        "widget" => FollowUpTableWidget::class,
+        "x" => 0,
+        "y" => 2,
+        "w" => 12,
+    ],
+    [
+        "widget" => PaymentRemindersTableWidget::class,
+        "x" => 0,
+        "y" => 3,
+        "w" => 12,
+    ]
 ];

--- a/src/GridstackDashboardPlugin.php
+++ b/src/GridstackDashboardPlugin.php
@@ -6,10 +6,22 @@ use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
 use InvadersXX\FilamentGridstackDashboard\Filament\Pages\Dashboard;
+use Closure;
 
 class GridstackDashboardPlugin implements Plugin
 {
     use EvaluatesClosures;
+
+    protected int | Closure  | null $navigationSort = null;
+
+    protected bool | Closure | null $shouldRegisterNavigation = null;
+
+    protected string | Closure | null $navigationGroup = null;
+
+    protected array | Closure | null $allowedWidgets = null;
+
+    protected array | Closure | null $emptyStateWidgets = null;
+
 
     protected string $settingsPath = 'dashboard.layout';
 
@@ -53,5 +65,65 @@ class GridstackDashboardPlugin implements Plugin
 
     public function boot(Panel $panel): void
     {
+    }
+
+    public function shouldRegisterNavigation(): ?bool
+    {
+        return $this->evaluate($this->shouldRegisterNavigation) ?? config('gridstack-dashboard.should_register_navigation');
+    }
+
+    public function navigationGroup(string | Closure | null $group = null): static
+    {
+        $this->navigationGroup = $group;
+
+        return $this;
+    }
+
+    public function navigationSort(int | Closure $order): static
+    {
+        $this->navigationSort = $order;
+
+        return $this;
+    }
+
+    public function registerNavigation(bool | Closure $condition = true): static
+    {
+        $this->shouldRegisterNavigation = $condition;
+
+        return $this;
+    }
+
+    public function allowedWidgets(array | Closure $widgets): static
+    {
+        $this->allowedWidgets = $widgets;
+
+        return $this;
+    }
+
+    public function emptyStateWidgets(array | Closure $widgets): static
+    {
+        $this->emptyStateWidgets = $widgets;
+
+        return $this;
+    }
+
+    public function getNavigationSort(): ?int
+    {
+        return $this->evaluate($this->navigationSort) ?? config('gridstack-dashboard.navigation_sort');
+    }
+
+    public function getNavigationGroup(): ?string
+    {
+        return $this->evaluate($this->navigationGroup) ?? config('gridstack-dashboard.navigation_group');
+    }
+
+    public function getAllowedWidgets(): ?array
+    {
+        return $this->evaluate($this->allowedWidgets) ?? config('gridstack-dashboard.allowed_widgets');
+    }
+
+    public function getEmptyStateWidgets(): ?array
+    {
+        return $this->evaluate($this->emptyStateWidgets) ?? config('gridstack-dashboard.empty_state_widgets');
     }
 }


### PR DESCRIPTION
Awesome plugin! Some clients have been asking this to us for quite some time, so I made some slight changes so we can start using this soon! :) 

This PR has the following functionality:

1) Setting an empty state when no widgets are set

2) Only allowing specific widgets to be selected by the user

3) Set some basic functions on the page (shouldRegisterNavigation, navigationSort and navigationGroup).